### PR TITLE
Canal Excavator Compatibility

### DIFF
--- a/compatibility/canal-excavator.lua
+++ b/compatibility/canal-excavator.lua
@@ -1,0 +1,34 @@
+if not mods["canal-excavator"] then return end
+
+data:extend({{
+  type = "mod-data",
+  name = "canex-lemures-config",
+  data_type = "canex-surface-config",
+  data = {
+    surfaceName = "lemures",
+    localisation = {"space-location-name.lemures"},
+    oreStartingAmount = 50,
+    mining_time = 1,
+    tint = {r = 159, g = 193, b = 222},
+    mineResult = {
+      {type="item", name = "ice", probability = 0.95, amount = 1},
+      {type="item", name = "fossil", probability = 0.05, amount = 1},
+    }
+  }
+},
+{
+  type = "mod-data",
+  name = "canex-prosephina-config",
+  data_type = "canex-surface-config",
+  data = {
+    surfaceName = "prosephina",
+    localisation = {"space-location-name.prosephina"},
+    oreStartingAmount = 20,
+    mining_time = 2,
+    tint = {r = 205, g = 133, b = 63},
+    mineResult = {
+      {type="item", name = "stone", probability = 0.6, amount = 1},
+      {type="item", name = "rich-soil", probability = 0.4, amount = 1},
+    }
+  }
+}})

--- a/data.lua
+++ b/data.lua
@@ -96,3 +96,5 @@ if tech and tech.effects then
         end
     end
 end
+
+require("compatibility.canal-excavator")

--- a/info.json
+++ b/info.json
@@ -22,6 +22,7 @@
     "? Better_Starmap_Background",
     "? dredgeworks >= 0.7.4",
     "? atan-nuclear-science",
+    "? canal-excavator >= 1.12",
     "! fixLargeElectricPole"
   ],
   "space_travel_required": true,


### PR DESCRIPTION
Hi,

Some users of my [Canal Excavator](https://mods.factorio.com/mod/canal-excavator) mod asked me to implement compatibility with more planet mods.
Personally I think it's cleaner if the compatibility code is in the planet mod so let me know if you're okay with adding this.

As you can see in the file in the compatibility folder, I configured Lemures to yield mainly ice when excavated. But I thought it might be interesting to also yield a small amount of fossils.

Excavating on Prosephina yields a mix of stone and rich soil. I've tweaked the numbers such that it can't be used to cheese landfill, but you can reduce it even more if you want.

In any case, you can tweak the parameters in the as you see fit, they are your planets after all!

Let me know what you think.